### PR TITLE
feat: Refactor instagramGetUrl function

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@
 <a href="#"><img title="MAINTENED" src="https://img.shields.io/badge/MAINTENED-YES-%23833AB4?style=flat-square"/></a>
 </p>
 
-## Instalation :
+## Installation
 ```bash
-> npm i --save instagram-url-direct
+> npm install --save instagram-url-direct
 ```
 
 ## Example
 ```js
-const instagramGetUrl = require("instagram-url-direct")
-let links = await instagramGetUrl("https://www.instagram.com/tv/CdmYaq3LAYo/")
-console.log(links)
+const instagramGetUrl = require('instagram-url-direct');
+const data = await instagramGetUrl('https://www.instagram.com/p/CpTo4jfPJiz');
+console.log(data);
 ```
-## Output Example
+## Output
 ```
-{
-    results_number : 1,
-    url_list : [
-        'https://scontent.cdninstagram.com/v/t50.2886-16/281176759_330829732466343_6214175692160325206_n.mp4?_nc_ht=scontent.cdninstagram.com&_nc_cat=103&_nc_ohc=tsiSkUxDxfEAX-u8MmX&edm=AJBgZrYBAAAA&ccb=7-5&oe=62D43703&oh=00_AT-8ndeJFByZE0H6IqNwZasKMBfaqXRiwGoFL1tR_RSflA&_nc_sid=78c662'
-    ]
-}
+[
+  {
+    fileExtension: 'jpg',
+    directUrl: 'https://scontent.cdninstagram.com/v/t51.2885-15/331124941_920301342353839_7915519387355868397_n.jpg?stp=dst-jpg_e35_s1080x1080&_nc_ht=scontent.cdninstagram.com&_nc_cat=107&_nc_ohc=urHySRc88YwAX-epd64&edm=APs17CUBAAAA&ccb=7-5&oh=00_AfBcED1UAH3jadGIflN2OcoU9DT6zCucixhi9WG2p0qSkQ&oe=640DCAE9&_nc_sid=978cb9&dl=1'
+  }
+]
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,53 +1,51 @@
-const axios = require("axios")
-module.exports = instagramGetUrl = (url_media) =>{
-    return new Promise(async (resolve,reject)=>{
-        const BASE_URL = "https://instasupersave.com/"
-        
-        //New Session = Cookies
-        try {
-            const resp = await axios(BASE_URL);
-            const cookie = resp.headers["set-cookie"]; // get cookie from request
-            const session = cookie[0].split(";")[0].replace("XSRF-TOKEN=","").replace("%3D", "")
-            
-            //REQUEST CONFIG
-            var config = {
-                method: 'post',
-                url: `${BASE_URL}api/convert`,
-                headers: { 
-                    'origin': 'https://instasupersave.com', 
-                    'referer': 'https://instasupersave.com/pt/', 
-                    'sec-fetch-dest': 'empty', 
-                    'sec-fetch-mode': 'cors', 
-                    'sec-fetch-site': 'same-origin', 
-                    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 Edg/107.0.1418.52', 
-                    'x-xsrf-token': session, 
-                    'Content-Type': 'application/json', 
-                    'Cookie': `XSRF-TOKEN=${session}; instasupersave_session=${session}`
-                },
-                data : {
-                    url: url_media
-                }
-            };
+const axios = require('axios');
 
-            //REQUEST
-            axios(config).then(function (response) {
-                let ig = []
-                if(Array.isArray(response.data)){
-                    response.data.forEach(post => { ig.push(post.sd === undefined ? post.thumb : post.sd.url)})
-                } else {
-                    ig.push(response.data.url[0].url)    
-                }
-                
-                resolve({
-                    results_number : ig.length,
-                    url_list: ig
-                })
-            })
-            .catch(function (error) {
-                reject(error.message)
-            })
-        } catch(e){
-            reject(e.message)
-        }
-    })
+/** 
+ * This function intakes an instagramUrl of an image or video post, reel, or public account stories using InstaSuperSave API.
+ * @param {string} instagramUrl - The Instagram URL to convert.
+ * @returns {Promise<Array<{fileExtension: string, rawUrl: string}> | string>} An array of objects containing fileExtension and rawUrl properties, If the API call fails, returns error message with additional information.
+ */
+async function instagramGetUrl(instagramUrl) {
+    const api = 'https://instasupersave.com';
+	// Collect cookie from session.
+	try {
+		const {
+			headers: { 'set-cookie': cookie }
+		} = await axios(api);
+		const session = String(cookie[0].split(';')[0]).replace('XSRF-TOKEN=', '').replace('%3D', '');
+
+		// Setup request headers.
+		const requestHeaders = {
+			method: 'POST',
+			url: `${api}/api/convert`,
+			headers: {
+				'Origin': api,
+				'Referer': `${api}/pt/`,
+				'Sec-Fetch-Dest': 'empty',
+				'Sec-Fetch-Mode': 'cors',
+				'Sec-Fetch-Site': 'same-origin',
+				'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36 Edg/107.0.1418.52',
+				'X-XSRF-Token': session,
+				'Content-Type': 'application/json',
+				'Cookie': `XSRF-TOKEN=${session}; instasupersave_session=${session}`
+			},
+			data: { url: instagramUrl }
+		};
+
+		// Call the API and process the data.
+		const { data } = await axios(requestHeaders);
+		return data.map(({ url }) => {
+			const { ext: fileExtension, url: rawUrl } = url[0];
+			return { fileExtension, rawUrl };
+		});
+	} catch (error) {
+		return (await import('util')).format(
+			'[instagram-direct-url] %s (Status: %s, Status Text: %s)', 
+			error?.message || 'An error occurred.', 
+			error?.response?.status || 'None', 
+			error?.response?.statusText || 'None'
+		);
+	}
 }
+
+module.exports = instagramGetUrl;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 const axios = require('axios');
 
 /** 
- * This function intakes an instagramUrl of an image or video post, reel, or public account stories using InstaSuperSave API.
+ * This function intakes an instagramUrl of an image or video post, reel, or public account stories and returns with direct url using InstaSuperSave API.
  * @param {string} instagramUrl - The Instagram URL to convert.
- * @returns {Promise<Array<{fileExtension: string, rawUrl: string}> | string>} An array of objects containing fileExtension and rawUrl properties, If the API call fails, returns error message with additional information.
+ * @returns {Promise<Array<{fileExtension: string, directUrl: string}> | string>} An array of objects containing fileExtension and directUrl properties, If the API call fails, returns error message with additional information.
  */
 async function instagramGetUrl(instagramUrl) {
-    const api = 'https://instasupersave.com';
+	const api = 'https://instasupersave.com';
 	// Collect cookie from session.
 	try {
 		const {
@@ -34,15 +34,18 @@ async function instagramGetUrl(instagramUrl) {
 
 		// Call the API and process the data.
 		const { data } = await axios(requestHeaders);
-		return data.map(({ url }) => {
-			const { ext: fileExtension, url: rawUrl } = url[0];
-			return { fileExtension, rawUrl };
-		});
+		// console.log(data);
+		return Array.isArray(data)
+			? data.map((item) => {
+				const { ext: fileExtension, url: directUrl } = item.url[0];
+				return { fileExtension, directUrl: item?.sd?.url || directUrl };
+			})
+			: [{ fileExtension: data.url[0].ext, directUrl: data.url[0].url }];
 	} catch (error) {
 		return (await import('util')).format(
-			'[instagram-direct-url] %s (Status: %s, Status Text: %s)', 
-			error?.message || 'An error occurred.', 
-			error?.response?.status || 'None', 
+			'[instagram-direct-url] %s (Status: %s, Status Text: %s)',
+			error?.message || 'An error occurred.',
+			error?.response?.status || 'None',
 			error?.response?.statusText || 'None'
 		);
 	}

--- a/src/test.js
+++ b/src/test.js
@@ -1,27 +1,18 @@
-const instagramGetUrl = require("./index")
+const instagramGetUrl = require('./index');
 
-async function test(url){
-    let result = await instagramGetUrl(url)
-    return result
+test('https://www.instagram.com/p/CMAMhvgsVal')
+    .then((results) => console.log('[test] videos and images: PASS.', results))
+    .catch((error) => console.log('[test] videos and images: FAIL.', error));
+
+test('https://www.instagram.com/p/CHSvvKXpkH6')
+    .then((results) => console.log('[test] image only: PASS.', results))
+    .catch((error) => console.log('[test] image only: FAIL.', error));
+
+test('https://www.instagram.com/tv/CdmYaq3LAYo')
+    .then((results) => console.log('[test] video only: PASS.', results))
+    .catch((error) => console.log('[test] video only: FAIL.', error));
+
+async function test(url) {
+    const results = await instagramGetUrl(url)
+    return results;
 }
-
-test("https://www.instagram.com/p/CMAMhvgsVal/").then(result=>{
-    console.log("Test Videos/Images OK")
-    console.log(result)
-}).catch(err=>{
-    console.error(err)
-})
-
-test("https://www.instagram.com/p/CHSvvKXpkH6/").then(result=>{
-    console.log("Test Only Image OK")
-    console.log(result)
-}).catch(err=>{
-    console.error(err)
-})
-
-test("https://www.instagram.com/tv/CdmYaq3LAYo/").then(result=>{
-    console.log("Test Only Video OK")
-    console.log(result)
-}).catch(err=>{
-    console.error(err)
-})


### PR DESCRIPTION
. This pull request refactors the `instagramGetUrl` function to improve code clarity, readability, and maintainability.  . The changes include:

- Updated the function to return scontent.cdninstagram.com links again instead of media.instasupersave.com links as shown in README.md.
- Updated function signature to include JSDoc comments describing the function and its parameters.
- Wrapped the function in an `async` block to allow for the use of `await`.
- Updated the try/catch block to use `await` instead of the `.then()` method.
- Refactored the `config ` variable to `requestHeaders` to better reflect its content.
- Make use of `const` instead of `var`.
- Updated the names of the input parameter and return values to reflect their use.
- Updated the `reject` return value to include the error message instead of just the message.
- Added a return value for when the API call fails to provide more information about the error.

. With contributions from: autumn1111 <autumnwtf@proton.me>