### PR TITLE
Download video instead of thumbnail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = instagramGetUrl = (url_media) =>{
 
             downloadItems.each((index, element) => {
                 const downloadLink = $(element)
-                .find(".download-items__btn > a")
+                .find(".download-items__btn:not(.dl-thumb) > a")
                 .attr("href")
                 result.push(downloadLink)
             })


### PR DESCRIPTION
saveig.app changed something, and now you have an option to download a thumbnail as well in case of stories for example,

Only a small change in 1 line fixes this, which i did.