### PR TITLE
deliver types for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Get direct url to download from Instagram media links",
   "main": "dist/esm/instagram.js",
+  "types": "dist/types/instagram.d.ts",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
This pull request adds the "types" property to the package.json file, in order for npm to deliver the types, allowing TypeScript users, use this package without getting the next error: `Could not find a declaration file for module 'instagram-url-direct'`.