### PR TITLE
Added owner_profile_pic to response

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ console.log(data)
     post_info: {
         owner_username: string,
         owner_fullname: string,
-        owner_profile_pic: "profile_pic_url",
+        owner_profile_pic: string,
         is_verified: boolean,
         is_private: boolean,
         likes: number,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ console.log(data)
     post_info:{
         owner_username: "username",
         owner_fullname: "fullname",
+        owner_profile_pic: "profile_pic_url",
         is_verified: false,
         is_private: false,
         likes: 6,
@@ -77,6 +78,7 @@ console.log(data)
     post_info:{
         owner_username: "username",
         owner_fullname: "fullname",
+        owner_profile_pic: "profile_pic_url",
         is_verified: false,
         is_private: false,
         likes: 10,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "instagram-url-direct",
+  "name": "wf-instagram-url-direct",
   "version": "2.0.7",
   "description": "Get direct url to download from Instagram media links",
   "main": "dist/instagram.js",
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/victorsouzaleal/instagram-direct-url.git"
+    "url": "git+https://github.com/webfork/instagram-direct-url.git"
   },
   "keywords": [
     "instagram",
@@ -39,9 +39,9 @@
   "author": "victorsouzaleal <victorsouzaleal@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/victorsouzaleal/instagram-direct-url/issues"
+    "url": "https://github.com/webfork/instagram-direct-url/issues"
   },
-  "homepage": "https://github.com/victorsouzaleal/instagram-direct-url#readme",
+  "homepage": "https://github.com/webfork/instagram-direct-url#readme",
   "dependencies": {
     "axios": "^1.7.7",
     "qs": "^6.13.0"

--- a/src/instagram.ts
+++ b/src/instagram.ts
@@ -8,6 +8,7 @@ export interface InstagramResponse {
     post_info: {
         owner_username: string,
         owner_fullname: string,
+        owner_profile_pic: string;
         is_verified: boolean,
         is_private: boolean,
         likes: number,
@@ -65,6 +66,7 @@ function formatPostInfo(requestData : any){
         return {
             owner_username: requestData.owner.username,
             owner_fullname: requestData.owner.full_name,
+            owner_profile_pic: requestData.owner.profile_pic_url,
             is_verified: requestData.owner.is_verified,
             is_private: requestData.owner.is_private,
             likes: requestData.edge_media_preview_like.count,


### PR DESCRIPTION
This pull request introduces a new field, `owner_profile_pic`, to the `post_info` object in the Instagram response. The changes ensure that this field is included in the API response, documented in the README, and properly handled in the code.

### Updates to API response structure:

* [`src/instagram.ts`](diffhunk://#diff-e80619259795bd67304a0c9c0b7f853bf0e013c6a4705a03e6006df6d4273999R11): Added the `owner_profile_pic` field (type `string`) to the `post_info` object in the `InstagramResponse` interface. This ensures the field is part of the API response.

### Enhancements to data formatting:

* [`src/instagram.ts`](diffhunk://#diff-e80619259795bd67304a0c9c0b7f853bf0e013c6a4705a03e6006df6d4273999R69): Updated the `formatPostInfo` function to include the `owner_profile_pic` field, mapping it to `requestData.owner.profile_pic_url`.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53): Updated example `console.log(data)` outputs to include the new `owner_profile_pic` field in the `post_info` object. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81)