### PR TITLE
fix: Changing URL of CSRF function and fixing an empty error message

### DIFF
--- a/src/instagram.ts
+++ b/src/instagram.ts
@@ -119,7 +119,7 @@ async function getCSRFToken(){
         const token = await new Promise <string>((resolve, reject) => {
             axios.request(config).then((response: AxiosResponse) => {
                 if (!response.headers['set-cookie']){
-                    reject({ message: "CSRF token not found in response headers." })
+                    reject(new Error('CSRF token not found in response headers.'))
                 } else {
                     const csrfCookie = response.headers['set-cookie'][0]
                     const csrfToken = csrfCookie.split(";")[0].replace("csrftoken=", '')

--- a/src/instagram.ts
+++ b/src/instagram.ts
@@ -113,13 +113,13 @@ async function getCSRFToken(){
     try {
         let config : AxiosRequestConfig = {
             method: 'GET',
-            url: 'https://www.instagram.com/graphql/query/?doc_id=7950326061742207&variables=%7B%22id%22%3A%2259237287799%22%2C%22include_clips_attribution_info%22%3Afalse%2C%22first%22%3A12%7D',
+            url: 'https://www.instagram.com/',
         }
 
         const token = await new Promise <string>((resolve, reject) => {
             axios.request(config).then((response: AxiosResponse) => {
                 if (!response.headers['set-cookie']){
-                    reject()
+                    reject({ message: "CSRF token not found in response headers." })
                 } else {
                     const csrfCookie = response.headers['set-cookie'][0]
                     const csrfToken = csrfCookie.split(";")[0].replace("csrftoken=", '')


### PR DESCRIPTION
The URL used on "getCSRFToken" doesnt work anymore, requesting "https://www.instagram.com/" instead solves the issue.
I've also fixed an empty rejection that would break everything and not give any descriptive error.

Issue: https://github.com/victorsouzaleal/instagram-direct-url/issues/38